### PR TITLE
WidthOfScreen and HeightOfScreen implementation

### DIFF
--- a/src/core/na-gtk-utils.c
+++ b/src/core/na-gtk-utils.c
@@ -31,6 +31,7 @@
 #include <config.h>
 #endif
 
+#include <gdk/gdkx.h>
 #include <glib.h>
 #include <string.h>
 
@@ -172,10 +173,8 @@ na_gtk_utils_restore_window_position( GtkWindow *toplevel, const gchar *wsp_name
 		} else {
 			display = gdk_display_get_default();
 			screen = gdk_display_get_default_screen( display );
-
-			gdk_window_get_geometry (gdk_screen_get_root_window( screen ), NULL, NULL,
-			                         &screen_width, &screen_height);
-
+			screen_width = WidthOfScreen (gdk_x11_screen_get_xscreen (screen));
+			screen_height = HeightOfScreen (gdk_x11_screen_get_xscreen (screen));
 			g_debug( "%s: screen=(%d,%d), DEFAULT_HEIGHT=%d",
 					thisfn, screen_width, screen_height, DEFAULT_HEIGHT );
 


### PR DESCRIPTION
This commit reverts:

https://github.com/raveit65/caja-actions/commit/5055b5984372f09608d568680f2382f447a9b17e

And it applies an alternative to fix the deprecated functions:

gdk_screen_get_width
gdk_screen_get_height