### PR TITLE
fix typo: 'unknown' instead 'unknwon'

### DIFF
--- a/src/api/na-iio-provider.h
+++ b/src/api/na-iio-provider.h
@@ -442,7 +442,7 @@ typedef struct {
  * @NA_IIO_PROVIDER_STATUS_ITEM_READONLY:     item is read-only.
  * @NA_IIO_PROVIDER_STATUS_NO_PROVIDER_FOUND: no writable i/o provider found.
  * @NA_IIO_PROVIDER_STATUS_LEVEL_ZERO:        level zero is not writable.
- * @NA_IIO_PROVIDER_STATUS_UNDETERMINED:      unknwon reason (and probably a bug).
+ * @NA_IIO_PROVIDER_STATUS_UNDETERMINED:      unknown reason (and probably a bug).
  *
  * The reasons for which an item may not be writable.
  *

--- a/src/core/na-desktop-environment.c
+++ b/src/core/na-desktop-environment.c
@@ -175,7 +175,7 @@ na_desktop_environment_get_label( const gchar *id )
 		}
 	}
 
-	g_warning( "%s: unknwon desktop identifier: %s", thisfn, id );
+	g_warning( "%s: unknown desktop identifier: %s", thisfn, id );
 
 	return( id );
 }


### PR DESCRIPTION
based in debian patch by @sunweaver 

https://salsa.debian.org/debian-mate-team/caja-actions/blob/debian/1.8.3-4/debian/patches/1001_typo-fix.patch